### PR TITLE
update Mac OS build instructions and create dedicated install directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 PREFIX=/usr/local
+
+# for Mac OS
+#PREFIX=/opt/cgterm
+
 EXESUFFIX=
 SOCKETLIBS=
 
@@ -81,8 +85,10 @@ install: all installdirs
 	cp cgedit$(EXESUFFIX) $(PREFIX)/bin/
 	cp *.bmp *.kbd *.wav $(PREFIX)/share/cgterm/
 
-installdirs: $(PREFIX)/bin $(PREFIX)/share $(PREFIX)/share/cgterm $(PREFIX)/etc
+installdirs: $(PREFIX) $(PREFIX)/bin $(PREFIX)/share $(PREFIX)/share/cgterm $(PREFIX)/etc
 
+$(PREFIX):
+	mkdir $(PREFIX) > /dev/null 2>&1
 $(PREFIX)/bin:
 	mkdir $(PREFIX)/bin > /dev/null 2>&1
 $(PREFIX)/share:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ if it's not included with your OS.
 
 Edit the supplied `Makefile` as needed, then run `make`, and `make install`.
 
+Installation (Mac OS)
+-------------------
+
+As above, cgterm requires SDL. To install SDL, you can use either [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/), or compile it yourself. You will also need the Xcode command-line tools.
+
+Next, edit `Makefile`, and specify the correct destination directory, as per the comment in the file. Last, run `make`, and `make install`.
+
 Usage
 -----
 


### PR DESCRIPTION
I updated the docs with info on installing SDL, and created a dedicated install directory option, in the Makefile, to make life easier for Mac folks who can't easily uninstall.